### PR TITLE
Add mouse aiming and persistent control preferences

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,16 @@ endif()
 
 add_executable(Snap64Recomp ${SNAP_SOURCES})
 
+# Focused production input regression harness; opt in by target.
+if (WIN32)
+    add_executable(SnapControlsTest EXCLUDE_FROM_ALL
+        tests/controls_test.cpp src/input.cpp)
+    target_include_directories(SnapControlsTest PRIVATE
+        "$<TARGET_PROPERTY:Snap64Recomp,INCLUDE_DIRECTORIES>")
+    target_compile_definitions(SnapControlsTest PRIVATE SDL_MAIN_HANDLED NOMINMAX)
+    target_link_libraries(SnapControlsTest PRIVATE SDL2::SDL2)
+endif()
+
 target_include_directories(Snap64Recomp PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/src"
     "${CMAKE_CURRENT_BINARY_DIR}/generated"

--- a/README.md
+++ b/README.md
@@ -194,6 +194,25 @@ deleted. The first start after the change rebuilds the cache once.
 
 ### Controls
 
+Mouse aiming defaults to enabled during a course. Hold **right mouse** for the
+viewfinder (N64 Z), then click **left mouse** to take a photo (N64 A). Mouse
+movement adds to the keyboard/controller stick, within the normal stick limit.
+The stage intro still temporarily restricts camera movement.
+
+| Control | Default binding | Saved preference |
+| --- | --- | --- |
+| Enable/release mouse aiming | M | `mouse_enabled`: `true` |
+| Toggle vertical aim inversion | Y | `invert_y`: `false` |
+| Lower/raise mouse sensitivity | Numpad − / + | `mouse_sensitivity`: `0.06` |
+
+These preferences save automatically in `snapsettings.json` beside the
+executable and restore on the next launch. Each sensitivity step multiplies
+by 0.8 or 1.25, bounded to `0.001`–`1.0`. The window title shows current values.
+Inversion affects combined mouse/keyboard/controller aim during a course;
+menus keep their usual directions. Capture hides the pointer while playing
+in the focused window, and releases it on pause, in menus, on focus loss, or
+when disabled with M. Replays use recorded input and never capture the mouse.
+
 Keyboard (`src/input.cpp`):
 
 | N64 | Key |

--- a/docs/MOUSE-CONTROLS.md
+++ b/docs/MOUSE-CONTROLS.md
@@ -1,0 +1,49 @@
+# Mouse controls
+
+Mouse aiming uses SDL relative motion while a course is running and the window
+has focus. Left mouse maps to A; hold right mouse for Z/the viewfinder, then
+click left to take a photo. The stage intro still locks the camera temporarily.
+
+| Preference | Binding | Default |
+| --- | --- | --- |
+| Mouse aim enabled | M | `mouse_enabled = true` |
+| Invert vertical aim | Y | `invert_y = false` |
+| Sensitivity | Numpad minus / plus | `mouse_sensitivity = 0.06` |
+
+Each sensitivity step multiplies by 0.8 or 1.25, within 0.001–1.0. All three
+preferences save through the existing debounced settings writer and restore
+on launch. Existing settings override defaults. Current values appear in the
+window title. Inversion applies to combined mouse, keyboard and controller
+aim during gameplay; menu navigation is unchanged.
+
+SDL event collection and relative-mode changes run on the main thread. Pending
+motion and held/latched button presses are protected by a mutex until a
+controller reading consumes them. A complete click between readings remains
+latched for one reading, and each motion delta is consumed once. The existing
+circular N64 stick limit remains in effect.
+
+The game thread publishes course/pause state using app_level residency and the
+retail `IsPaused` byte at `0x80382D20`. Capture releases and input clears on
+focus loss, pause, leaving the course, or disabling mouse aim. Replays use
+their recorded final input and never capture the mouse.
+
+## Validation
+
+On Windows, build the game and the optional production-input harness:
+
+```powershell
+cmake --build build-win --config Release --target Snap64Recomp SnapControlsTest
+& .\build-win\Release\SnapControlsTest.exe
+& .\build-win\Release\SnapControlsTest.exe --replay
+```
+
+Run from a writable directory; replay mode writes `controls-test.inputs` there.
+The harness briefly opens an SDL window and compiles production input code,
+with unrelated services and the settings store stubbed. It covers accumulated
+motion, quick clicks, held/released viewfinder, inversion, stick bounds, focus,
+pause, overlay transitions, disabling mouse aim, replay bypass, and replay EOF.
+It passed 27 live checks and 8 replay checks on Windows/VS2022.
+
+Separate real-application checks verified fresh defaults, numpad sensitivity,
+automatic saving of M alone, and all three preferences across three launches.
+Mouse controls were also playtested by the requester. Linux was not tested.

--- a/src/control_math.h
+++ b/src/control_math.h
@@ -1,0 +1,57 @@
+#ifndef SNAP_CONTROL_MATH_H
+#define SNAP_CONTROL_MATH_H
+
+#include <cstdint>
+
+namespace snap {
+
+// Protected by input.cpp's mutex across SDL's main thread and controller reads.
+// Keep a quick press until a controller read, even if SDL already saw release.
+struct MouseSample {
+    float x = 0.0f, y = 0.0f;
+    uint16_t buttons = 0;
+};
+
+class MouseAccumulator {
+    MouseSample pending;
+    uint16_t held = 0;
+    bool active = false;
+public:
+    void set_active(bool value) {
+        if (value != active) {
+            pending = {};
+            held = 0;
+            active = value;
+        }
+    }
+    bool is_active() const { return active; }
+    void motion(float x, float y) {
+        if (active) {
+            pending.x += x;
+            pending.y += y;
+        }
+    }
+    void button(uint16_t mask, bool down) {
+        if (!active) return;
+        if (down) {
+            held |= mask;
+            pending.buttons |= mask;
+        } else {
+            held &= ~mask;
+        }
+    }
+    MouseSample take() {
+        MouseSample result = pending;
+        result.buttons |= held;
+        pending = {};
+        return result;
+    }
+};
+
+inline void apply_mouse_aim(float& x, float& y, const MouseSample& mouse, float sensitivity) {
+    x += mouse.x * sensitivity;
+    y -= mouse.y * sensitivity;
+}
+
+} // namespace snap
+#endif

--- a/src/frame_cost.cpp
+++ b/src/frame_cost.cpp
@@ -48,6 +48,7 @@
 
 #include "hle/rt64_snap_diag.h"
 #include "settings.h"
+#include "input.h"
 #include "recomp.h"
 
 extern "C" {
@@ -135,6 +136,7 @@ extern "C" void gtlUpdate(uint8_t* rdram, recomp_context* ctx) {
     // Anything the in-game GRAPHICS page published since the last tick is
     // applied here, on the thread the page runs on. One word read when idle.
     snap::poll_menu_mailbox(rdram);
+    snap::input_update_game_state(rdram);
 
     const bool on = snapdiag::statsEnabled();
     if (!on) {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -41,6 +41,10 @@
 
 #include "photo_export.h"
 #include "snap_station.h"
+#include "settings.h"
+#include "control_math.h"
+#include "recomp.h"
+#include <mutex>
 
 // Pokemon Snap port: how many more presented images to photograph. Lives in
 // RT64's present queue, where the pictures actually leave for the screen;
@@ -78,6 +82,54 @@ extern uint8_t* g_rdram;
 
 static SDL_GameController* game_controller = nullptr;
 static bool controller_initialized = false;
+
+extern std::atomic<bool> g_app_level_resident;
+static std::atomic<bool> aim_active{false};
+static std::mutex mouse_mutex;
+static MouseAccumulator mouse;
+
+void input_update_game_state(uint8_t* rdram) {
+    // IsPaused belongs to app_level; it is not a valid variable in other scenes.
+    const bool playing = g_app_level_resident.load(std::memory_order_relaxed) &&
+        rdram != nullptr && MEM_BU(0, (gpr)(int32_t)0x80382D20) == 0;
+    aim_active.store(playing, std::memory_order_relaxed);
+}
+
+void input_update_window(SDL_Window* window) {
+    if (!window) return;
+    bool enabled;
+    {
+        std::lock_guard<std::mutex> lock(settings_mutex());
+        enabled = settings().mouse_enabled;
+    }
+    // Replays already contain the final mapped input and must not capture a
+    // player's pointer or incorporate live motion. Focus/menus clear all state.
+    static const bool replaying = std::getenv("SNAP_REPLAY") != nullptr;
+    const bool want = enabled && !replaying && aim_active.load(std::memory_order_relaxed) &&
+        g_app_level_resident.load(std::memory_order_relaxed) &&
+        (SDL_GetWindowFlags(window) & SDL_WINDOW_INPUT_FOCUS);
+    if (bool(SDL_GetRelativeMouseMode()) != want) {
+        if (SDL_SetRelativeMouseMode(want ? SDL_TRUE : SDL_FALSE) != 0) {
+            fprintf(stderr, "[SNAP-INPUT] mouse capture failed: %s\n", SDL_GetError());
+        }
+    }
+    std::lock_guard<std::mutex> lock(mouse_mutex);
+    mouse.set_active(want && SDL_GetRelativeMouseMode() == SDL_TRUE);
+}
+
+void input_handle_event(const SDL_Event& event) {
+    std::lock_guard<std::mutex> lock(mouse_mutex);
+    if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_FOCUS_LOST) {
+        mouse.set_active(false);
+        SDL_SetRelativeMouseMode(SDL_FALSE);
+    } else if (event.type == SDL_MOUSEMOTION) {
+        mouse.motion(float(event.motion.xrel), float(event.motion.yrel));
+    } else if (event.type == SDL_MOUSEBUTTONDOWN || event.type == SDL_MOUSEBUTTONUP) {
+        const uint16_t mask = event.button.button == SDL_BUTTON_LEFT ? N64_BTN_A :
+                              event.button.button == SDL_BUTTON_RIGHT ? N64_BTN_Z : 0;
+        mouse.button(mask, event.type == SDL_MOUSEBUTTONDOWN);
+    }
+}
 
 // The Back button's press, taken from SDL's event stream rather than from
 // the state polled below. The game reads button STATE (input_get, on the
@@ -414,6 +466,30 @@ bool input_get(int controller_num, uint16_t* buttons, float* x, float* y) {
             ax = gc_x * rescale;
             ay = gc_y * rescale;
         }
+    }
+
+    // Apply mouse motion once per controller reading. SDL only collects the
+    // deltas; the render/present rate does not decide how often they are used.
+    const bool aiming = aim_active.load(std::memory_order_relaxed) &&
+        g_app_level_resident.load(std::memory_order_relaxed);
+    float sensitivity;
+    bool inverted, mouse_enabled;
+    {
+        std::lock_guard<std::mutex> lock(settings_mutex());
+        sensitivity = settings().mouse_sensitivity;
+        inverted = settings().invert_y;
+        mouse_enabled = settings().mouse_enabled;
+    }
+    MouseSample sample;
+    {
+        std::lock_guard<std::mutex> lock(mouse_mutex);
+        if (!aiming || !mouse_enabled) mouse.set_active(false);
+        sample = mouse.take();
+    }
+    if (aiming) {
+        apply_mouse_aim(ax, ay, sample, sensitivity);
+        btn |= sample.buttons;
+        if (inverted) ay = -ay;
     }
 
     // Clamp analog values.

--- a/src/input.h
+++ b/src/input.h
@@ -12,6 +12,9 @@
 #include <cstdint>
 #include "ultramodern/input.hpp"
 
+union SDL_Event;
+struct SDL_Window;
+
 namespace snap {
 
 /**
@@ -19,6 +22,12 @@ namespace snap {
  * Called once per input poll cycle by the runtime.
  */
 void input_poll();
+
+// SDL window/event operations stay on the main thread. Guest state is sampled
+// on the game thread and published atomically, never read by the SDL thread.
+void input_update_game_state(uint8_t* rdram);
+void input_update_window(SDL_Window* window);
+void input_handle_event(const SDL_Event& event);
 
 /**
  * Get the current input state for a controller.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,11 +143,18 @@ static void snap_update_window_title() {
         return;
     }
 
-    char title[160];
-    snprintf(title, sizeof(title), "%s %s%s%s%s", SNAP_PORT_NAME, SNAP_PORT_VERSION,
+    char title[256];
+    snap::Settings controls;
+    {
+        std::lock_guard<std::mutex> lock(snap::settings_mutex());
+        controls = snap::settings();
+    }
+    snprintf(title, sizeof(title), "%s %s%s%s%s | Mouse %s (M) | Y %s (Y) | Sens %.3f (Num -/+)", SNAP_PORT_NAME, SNAP_PORT_VERSION,
              (snap::settings().fps_mode == 0) ? "" : " - interpolation ON (F8)",
              snap::settings().render_to_ram ? "" : " - render-to-RAM OFF (F6)",
-             snap::settings().interpolate_camera ? "" : " - camera lerp OFF (F4)");
+             snap::settings().interpolate_camera ? "" : " - camera lerp OFF (F4)",
+             controls.mouse_enabled ? "on" : "off", controls.invert_y ? "inverted" : "normal",
+             controls.mouse_sensitivity);
     SDL_SetWindowTitle(sdl_window, title);
 }
 
@@ -187,7 +194,9 @@ static void update_gfx(void* /*gfx_data*/) {
     }
 
     SDL_Event event;
+    snap::input_update_window(sdl_window);
     while (SDL_PollEvent(&event)) {
+        snap::input_handle_event(event);
         switch (event.type) {
             case SDL_QUIT:
                 // Named in the log because an unattended session was seen
@@ -198,6 +207,7 @@ static void update_gfx(void* /*gfx_data*/) {
                 ultramodern::quit();
                 break;
             case SDL_KEYDOWN:
+                if (event.key.repeat) break;
                 if (snap::handle_settings_hotkey(event.key.keysym.scancode)) {
                     snap_update_window_title();
                     break;
@@ -239,6 +249,8 @@ static void update_gfx(void* /*gfx_data*/) {
                 break;
         }
     }
+
+    snap::input_update_window(sdl_window);
 
     // The GRAPHICS and SOUND pages and the hotkeys only mark the settings
     // dirty; the file is written here, on the main thread, once the edits

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <filesystem>
@@ -90,6 +91,11 @@ static SettingsRead read_settings_file(const std::filesystem::path& path, Settin
         f >> j;
         Settings s = out;
         s.widescreen         = j.value("widescreen", s.widescreen);
+        s.mouse_enabled      = j.value("mouse_enabled", s.mouse_enabled);
+        s.mouse_sensitivity  = j.value("mouse_sensitivity", s.mouse_sensitivity);
+        if (!std::isfinite(s.mouse_sensitivity)) s.mouse_sensitivity = 0.06f;
+        s.mouse_sensitivity  = std::clamp(s.mouse_sensitivity, 0.001f, 1.0f);
+        s.invert_y           = j.value("invert_y", s.invert_y);
         s.msaa               = j.value("msaa", s.msaa);
         s.fps_mode           = j.value("fps_mode", s.fps_mode);
         s.fps_manual_target  = j.value("fps_manual_target", s.fps_manual_target);
@@ -228,6 +234,9 @@ bool save_settings() {
     const nlohmann::json j{
         {"fullscreen",            copy.fullscreen},
         {"widescreen",            copy.widescreen},
+        {"mouse_enabled",        copy.mouse_enabled},
+        {"mouse_sensitivity",    copy.mouse_sensitivity},
+        {"invert_y",             copy.invert_y},
         {"msaa",                  copy.msaa},
         {"fps_mode",              copy.fps_mode},
         {"fps_manual_target",     copy.fps_manual_target},
@@ -351,6 +360,31 @@ static bool toggle_locked(bool Settings::*flag) {
 
 bool handle_settings_hotkey(int scancode) {
     switch (scancode) {
+        case SDL_SCANCODE_M: {
+            const bool on = toggle_locked(&Settings::mouse_enabled);
+            settings_mark_dirty();
+            printf("[SNAP-INPUT] mouse aiming: %s (M)\n", on ? "on" : "off");
+            return true;
+        }
+        case SDL_SCANCODE_Y: {
+            const bool on = toggle_locked(&Settings::invert_y);
+            settings_mark_dirty();
+            printf("[SNAP-INPUT] invert aim Y: %s (Y)\n", on ? "on" : "off");
+            return true;
+        }
+        case SDL_SCANCODE_KP_MINUS:
+        case SDL_SCANCODE_KP_PLUS: {
+            float sensitivity;
+            {
+                std::lock_guard<std::mutex> lock(s_settings_mutex);
+                const float factor = scancode == SDL_SCANCODE_KP_PLUS ? 1.25f : 0.8f;
+                sensitivity = s_settings.mouse_sensitivity =
+                    std::clamp(s_settings.mouse_sensitivity * factor, 0.001f, 1.0f);
+            }
+            settings_mark_dirty();
+            printf("[SNAP-INPUT] mouse sensitivity: %.3f (numpad - / +)\n", sensitivity);
+            return true;
+        }
         case SDL_SCANCODE_F11:
             toggle_locked(&Settings::fullscreen);
             apply_graphics_settings();

--- a/src/settings.h
+++ b/src/settings.h
@@ -19,6 +19,9 @@ namespace snap {
 struct Settings {
     bool  fullscreen        = false;
     bool  widescreen        = false;  // RT64 Expand: true 16:9 FOV, not a stretch
+    bool  mouse_enabled     = true;   // default on; saved preference, M toggles live
+    float mouse_sensitivity = 0.06f;  // stick deflection per relative mouse pixel
+    bool  invert_y          = false;  // saved preference; Y toggles live
     int   msaa              = 0;      // 0, 2, 4, 8
     // 0 = Original (native rate), 1 = Display refresh, 2 = Manual.
     //

--- a/tests/controls_test.cpp
+++ b/tests/controls_test.cpp
@@ -1,0 +1,128 @@
+// Exercises the production SDL-to-N64 mapping. Only unrelated photo/station
+// services and the settings store are stubbed.
+#include "input.h"
+#include "settings.h"
+#include "control_math.h"
+#include "recomp.h"
+#include <SDL2/SDL.h>
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <mutex>
+#include <vector>
+
+extern "C" { std::atomic<int32_t> snap_frame_dump_pending{0}; }
+namespace snap {
+uint8_t* g_rdram = nullptr;
+std::atomic<bool> g_app_level_resident{false};
+Settings test_settings;
+std::mutex test_mutex;
+Settings& settings() { return test_settings; }
+std::mutex& settings_mutex() { return test_mutex; }
+void export_photo(uint8_t*) {}
+void photo_export_on_reading(uint8_t*) {}
+bool station_port4_present() { return false; }
+}
+
+static int checks = 0;
+static void check(bool ok, const char* what) {
+    if (!ok) { std::fprintf(stderr, "FAIL: %s (%s)\n", what, SDL_GetError()); std::exit(1); }
+    ++checks;
+}
+static bool close(float a, float b) { return std::fabs(a - b) < 0.0001f; }
+static void motion(int x, int y) {
+    SDL_Event e{}; e.type = SDL_MOUSEMOTION; e.motion.xrel = x; e.motion.yrel = y;
+    snap::input_handle_event(e);
+}
+static void button(uint8_t b, bool down) {
+    SDL_Event e{}; e.type = down ? SDL_MOUSEBUTTONDOWN : SDL_MOUSEBUTTONUP;
+    e.button.button = b; snap::input_handle_event(e);
+}
+static snap::MouseSample read() {
+    snap::MouseSample s;
+    check(snap::input_get(0, &s.buttons, &s.x, &s.y), "port zero available");
+    return s;
+}
+
+int main(int argc, char**) {
+    const bool replay = argc > 1;
+    if (replay) {
+        struct Reading { uint16_t buttons; float x, y; } r{0x8000, .25f, -.125f};
+        FILE* f = std::fopen("controls-test.inputs", "wb");
+        check(f != nullptr, "create replay fixture");
+        std::fwrite(&r, sizeof(r), 1, f); std::fclose(f);
+        _putenv_s("SNAP_REPLAY", "controls-test.inputs");
+    } else {
+        _putenv_s("SNAP_REPLAY", "");
+    }
+    check(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER) == 0, "SDL init");
+    SDL_Window* window = SDL_CreateWindow("Snap controls verification", SDL_WINDOWPOS_CENTERED,
+                                         SDL_WINDOWPOS_CENTERED, 320, 240, SDL_WINDOW_SHOWN);
+    check(window != nullptr, "test window");
+    SDL_RaiseWindow(window);
+    for (int i = 0; i < 100 && !(SDL_GetWindowFlags(window) & SDL_WINDOW_INPUT_FOCUS); ++i) {
+        SDL_PumpEvents(); SDL_Delay(10);
+    }
+    std::vector<uint8_t> memory(16 * 1024 * 1024);
+    uint8_t* rdram = memory.data();
+    snap::g_rdram = rdram;
+    snap::g_app_level_resident = true;
+    // Exercise an inverted preference independently of fresh-profile defaults.
+    snap::settings().invert_y = true;
+    snap::input_update_game_state(rdram);
+    snap::input_update_window(window);
+    if (replay) {
+        check(SDL_GetRelativeMouseMode() == SDL_FALSE, "replay never captures mouse");
+        motion(100, 100); button(SDL_BUTTON_RIGHT, true);
+        auto s = read();
+        check(s.buttons == 0x8000 && close(s.x, .25f) && close(s.y, -.125f),
+              "replay bypasses live controls and inversion");
+        s = read();
+        check(s.buttons == 0 && s.x == 0 && s.y == 0, "replay EOF neutral");
+    } else {
+        check(SDL_GetRelativeMouseMode() == SDL_TRUE, "playing captures mouse");
+        constexpr float scale = 80.5f / 127.0f;
+        motion(2, 3); motion(1, -1);
+        button(SDL_BUTTON_LEFT, true); button(SDL_BUTTON_LEFT, false);
+        auto s = read();
+        check(s.buttons == 0x8000, "quick left click survives release before controller read");
+        check(close(s.x, .18f * scale) && close(s.y, .12f * scale), "accumulated mouse and inverted Y");
+        s = read();
+        check(s.buttons == 0 && s.x == 0 && s.y == 0, "motion and quick press consumed once");
+        button(SDL_BUTTON_RIGHT, true);
+        check(read().buttons == 0x2000 && read().buttons == 0x2000, "right button holds viewfinder");
+        button(SDL_BUTTON_RIGHT, false);
+        check(read().buttons == 0, "viewfinder releases");
+        snap::settings().invert_y = false;
+        motion(0, 2);
+        check(close(read().y, -.12f * scale), "live normal Y");
+        motion(100000, -100000); s = read();
+        check(std::hypot(s.x, s.y) <= scale + .0001f, "mouse respects N64 circular stick range");
+        motion(5, 5); button(SDL_BUTTON_LEFT, true);
+        SDL_Event lost{}; lost.type = SDL_WINDOWEVENT; lost.window.event = SDL_WINDOWEVENT_FOCUS_LOST;
+        snap::input_handle_event(lost);
+        s = read();
+        check(s.buttons == 0 && s.x == 0 && s.y == 0, "focus loss clears held clicks and motion");
+        check(SDL_GetRelativeMouseMode() == SDL_FALSE, "focus loss releases pointer");
+        snap::input_update_window(window);
+        s = read(); check(s.buttons == 0 && s.x == 0 && s.y == 0, "recapture starts neutral");
+        MEM_B(0, (gpr)(int32_t)0x80382D20) = 1;
+        snap::input_update_game_state(rdram); snap::input_update_window(window);
+        check(SDL_GetRelativeMouseMode() == SDL_FALSE, "pause releases capture");
+        motion(5, 5); button(SDL_BUTTON_LEFT, true); s = read();
+        check(s.buttons == 0 && s.x == 0 && s.y == 0, "paused mouse does not navigate menus");
+        MEM_B(0, (gpr)(int32_t)0x80382D20) = 0;
+        snap::g_app_level_resident = false;
+        snap::input_update_game_state(rdram); snap::input_update_window(window);
+        check(SDL_GetRelativeMouseMode() == SDL_FALSE, "other overlays release capture");
+        snap::g_app_level_resident = true;
+        snap::settings().mouse_enabled = false;
+        snap::input_update_game_state(rdram); snap::input_update_window(window);
+        check(SDL_GetRelativeMouseMode() == SDL_FALSE, "M disable persists in a course");
+    }
+
+    SDL_SetRelativeMouseMode(SDL_FALSE);
+    SDL_DestroyWindow(window); SDL_Quit();
+    std::printf("PASS: %d production input checks (%s)\n", checks, replay ? "replay" : "live");
+}


### PR DESCRIPTION
Adds mouse aiming during courses, left-click photos, and right-button viewfinder control. Mouse enable, sensitivity, and vertical aim inversion save automatically in `snapsettings.json` and restore across launches. Current values appear in the window title, with keyboard shortcuts for adjustment.

**AI disclosure:** This PR was generated using AI assistance (OpenAI Codex), including the implementation, tests, documentation, and PR description. The requester playtested the mouse controls and reported that they work well.

| Action | Default binding | Default preference |
| --- | --- | --- |
| Aim | Mouse movement | Mouse enabled (`mouse_enabled: true`) |
| Take a photo / N64 A | Left mouse button | Hold the viewfinder first |
| Viewfinder / N64 Z | Hold right mouse button | Release to leave the viewfinder |
| Enable/release mouse aiming | M | Saved across sessions |
| Toggle vertical aim inversion | Y | Off (`invert_y: false`); existing saved preferences take precedence |
| Decrease sensitivity | Numpad minus | Multiply by 0.8 |
| Increase sensitivity | Numpad plus | Multiply by 1.25 |

Sensitivity defaults to `0.06` and is bounded to `0.001`–`1.0`. Inversion applies to combined mouse, keyboard, and controller aim during gameplay. Existing keyboard/controller bindings and menu navigation remain available.

SDL relative mode captures/hides the pointer during focused course gameplay. Pausing, leaving a course, losing focus, or disabling mouse aim releases capture and clears pending input. Replays use their recorded final input and do not capture the mouse. The game's stage intro still temporarily restricts camera movement.

Motion is accumulated until a controller reading consumes it once. A press latch preserves a complete click between readings, held buttons remain held, and the existing circular N64 stick limit is respected. SDL operations stay on the main thread; the game thread publishes course/pause state for capture and inversion.

Validation on Windows with VS2022:

- Release game and optional `SnapControlsTest` target build successfully.
- Production-input harness passes 27 live checks and 8 replay checks, covering motion, quick clicks, held/released buttons, inversion, stick limits, focus/pause/course transitions, mouse disable, replay bypass, and EOF.
- Real application checks verify fresh defaults, numpad sensitivity changes, M auto-save, and all three preferences across three launches.
- Existing executable subsystem, icon, and settings checks pass. Mouse behavior was also playtested by the requester. Linux was not tested.

`README.md` documents the bindings; `docs/MOUSE-CONTROLS.md` explains behavior and how to run the harness. Game saves, ROMs, local settings, and generated game code are not included.

Widescreen Pokémon culling remains unresolved and is outside this PR. The earlier experimental culling changes are excluded.
