### PR TITLE
Fix Pokemon culling in widescreen side margins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,7 @@ set(SNAP_SOURCES
     src/rsp_microcode.cpp
     src/audio.cpp
     src/input.cpp
+    src/widescreen.cpp
     src/os_stubs.cpp
     src/overlay_hook.cpp
     src/matrix_tags.cpp
@@ -270,6 +271,13 @@ if (MSVC)
 endif()
 
 add_executable(Snap64Recomp ${SNAP_SOURCES})
+
+add_executable(SnapVisibilityTest EXCLUDE_FROM_ALL tests/visibility_test.cpp src/widescreen.cpp)
+target_include_directories(SnapVisibilityTest PRIVATE
+    "$<TARGET_PROPERTY:rt64,INCLUDE_DIRECTORIES>"
+    "$<TARGET_PROPERTY:Snap64Recomp,INCLUDE_DIRECTORIES>")
+target_compile_definitions(SnapVisibilityTest PRIVATE "$<TARGET_PROPERTY:rt64,COMPILE_DEFINITIONS>")
+target_link_libraries(SnapVisibilityTest PRIVATE rt64)
 
 target_include_directories(Snap64Recomp PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/src"

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ the defaults below are that file's.
 | Key | Default | Meaning |
 | --- | --- | --- |
 | `fullscreen` | `false` | not persisted across runs: every boot starts windowed, except that the Snap Station's own relaunches return in the state the print started in |
-| `widescreen` | `false` | RT64 Expand: a true 16:9 field of view, not a stretch; the game still culls by its 4:3 view, so objects at the edges vanish ("Known limitations") |
+| `widescreen` | `false` | RT64 Expand: field of view follows the window aspect ratio; Pokémon remain visible beyond the original 4:3 edges (see [visibility details](docs/WIDESCREEN-CULLING.md)) |
 | `msaa` | `0` | 0, 2, 4 or 8 |
 | `fps_mode` | `0` | 0 Original, 1 Display refresh, 2 Manual (`fps_manual_target`) |
 | `fps_manual_target` | `120` | |
@@ -467,14 +467,13 @@ documentation.
 
 ## Known limitations
 
-* **Widescreen is untested beyond the Beach, and has a known fault there.**
-  The game decides what to draw from its own 4:3 view, so with the wider
-  field of view Pokémon and objects that sit outside the original frame's
-  edges are not drawn: they vanish at the sides of the picture and pop in
-  when the 4:3 frame reaches them. Widening the game's own culling needs a
-  game-side patch and is on the list for 1.0.1. Until then Widescreen is
-  what it says on the page, opt-in, and the console's 4:3 view is the one
-  every course was played and verified in.
+* **Widescreen validation currently covers the Beach.** The Pokémon cutoff
+  at the original 4:3 edges is fixed, with Beach replays checked at 16:9,
+  21:9, and 32:9, including the viewfinder and camera interpolation. Other
+  courses have not been visually revalidated in widescreen. Photo eligibility
+  and scoring retain the original game's rules. Draw distance remains outstanding
+  for a later change. See
+  [widescreen visibility](docs/WIDESCREEN-CULLING.md) for implementation and tests.
 * Some 2D content is drawn without a name the interpolation can pair
   (the photo panels, Oak's thumbnails and full-screen backgrounds while they
   slide during a transition) and steps at the game's rate when it moves;

--- a/docs/WIDESCREEN-CULLING.md
+++ b/docs/WIDESCREEN-CULLING.md
@@ -1,0 +1,62 @@
+# Widescreen visibility
+
+With Widescreen enabled, Pokémon can remain visible outside the original 4:3
+frame. The display bounds follow the current window shape, including changes
+while a course is running. The setting remains opt-in.
+
+## Why Pokémon disappeared
+
+The renderer calculates native dirty rectangles before expanding the projection.
+Pokémon Snap splits Pokémon rendering into separate framebuffer passes for its
+photo detector. When a Pokémon lies entirely outside the native viewport, its
+pass can have an empty native color rectangle. RT64 discarded that pass before
+widescreen projection could bring the Pokémon into view.
+
+`FramebufferPair::displayColorRect` supplies the perspective projection's scissor
+as a display-only fallback for such passes in an expanded view. The workload
+queue uses it when selecting passes and allocating display targets. Normal GPU
+clipping then determines visibility. Native color/depth dirty bounds remain
+unchanged; enlarging those also would create unnecessary RAM writeback and
+photo-scoring work. Empty 2D and orthographic passes keep their original behavior.
+
+For very wide views, the `Pokemon_GetFlag100` hook also refreshes draw eligibility
+using the current camera transform and an expanded horizontal frustum. This
+avoids relying on visibility flags last updated by the photo collector, whose
+list has only 12 slots. The hook preserves the guest calling context and does
+not modify the photo eligibility flag. Vertical and distance limits, scripted
+hiding, spawn timing, and the native photo rules remain in effect.
+
+## Outstanding work
+
+Draw distance remains outstanding and may be addressed in a later commit. This
+change fixes disappearance at the original horizontal frame edges; it does not
+extend the existing distance limits or change course spawning.
+
+## Validation
+
+Build the normal Release executable, and opt into the focused harness:
+
+```sh
+cmake --build build-win --config Release --target SnapVisibilityTest
+./build-win/Release/SnapVisibilityTest.exe
+```
+
+The harness runs 32 checks against the production framebuffer helper and guest
+hook: native/expanded pass selection, viewfinder scissors, non-perspective
+passes, retained RAM bounds, several aspect ratios, distance/depth/vertical
+rejection, photo flags, and preservation of the guest context and stack.
+
+Windows Release validation also used isolated profiles and deterministic Beach
+replays at 4:3, 16:9, 21:9, and 32:9. Captures cover the viewfinder, turning in both
+directions, and Pokémon outside the former frame edges. The 21:9 run enabled
+camera interpolation. A separate captured run resized the live window through
+16:9, 32:9, 4:3, and 21:9 with interpolation enabled. These runs reported no
+crash or graphics-buffer overflow.
+A photo regression replay produced 30 per-Pokémon scoring checks matching the
+healthy buffer signature and exported 40 photos without a crash. This verifies
+scoring-buffer consistency, not identical final scores between 4:3 and 21:9.
+The requester also playtested the fixed widescreen build and reported that it
+looks good. Other courses have not been visually revalidated with this change.
+
+The implementation, tests, and documentation were produced with AI assistance
+(OpenAI Codex).

--- a/lib/rt64/src/hle/rt64_framebuffer_pair.cpp
+++ b/lib/rt64/src/hle/rt64_framebuffer_pair.cpp
@@ -80,6 +80,23 @@ namespace RT64 {
     bool FramebufferPair::isEmpty() const {
         return (gameCallCount == 0) && startFbOperations.empty() && endFbOperations.empty();
     }
+
+    FixedRect FramebufferPair::displayColorRect(bool expandedView) const {
+        // Native dirty bounds are computed before aspect adjustment. A Pokemon
+        // can occupy a whole pass outside those bounds and still be visible in
+        // the expanded projection. Keep that pass for display; GPU clipping
+        // decides which pixels survive. Do not enlarge drawColorRect itself:
+        // it also controls native RDRAM writeback and photo-scoring work.
+        FixedRect bounds = drawColorRect;
+        if (expandedView && bounds.isEmpty()) {
+            for (uint32_t i = 0; i < projectionCount; ++i) {
+                const Projection &proj = projections[i];
+                if (proj.type == Projection::Type::Perspective && proj.gameCallCount > 0)
+                    bounds.merge(proj.scissorRect);
+            }
+        }
+        return bounds;
+    }
     
     bool FramebufferPair::earlyPresentCandidate() const {
         // Some games might use screen framebuffers as temporary output for some operations that are clearly

--- a/lib/rt64/src/hle/rt64_framebuffer_pair.h
+++ b/lib/rt64/src/hle/rt64_framebuffer_pair.h
@@ -60,5 +60,6 @@ namespace RT64 {
         int changeProjection(uint32_t transformsIndex, Projection::Type type);
         bool isEmpty() const;
         bool earlyPresentCandidate() const;
+        FixedRect displayColorRect(bool expandedView) const;
     };
 };

--- a/lib/rt64/src/hle/rt64_workload_queue.cpp
+++ b/lib/rt64/src/hle/rt64_workload_queue.cpp
@@ -564,11 +564,12 @@ namespace RT64 {
                 const auto &colorImg = fbPair.colorImage;
                 const auto &depthImg = fbPair.depthImage;
                 fixedResScale = workloadConfig.resolutionScale;
-                if (!fbPair.drawColorRect.isEmpty()) {
+                const FixedRect displayRect = fbPair.displayColorRect(workloadConfig.aspectRatioScale > 1.0f);
+                if (!displayRect.isEmpty()) {
                     colorFb = nullptr;
                     depthFb = nullptr;
                     nativeColorWidth = colorImg.width;
-                    nativeColorHeight = fbPair.drawColorRect.bottom(true);
+                    nativeColorHeight = displayRect.bottom(true);
 
                     // The height cannot be allowed to shrink to the geometry, because
                     // that height ends up clipping the geometry.
@@ -1170,7 +1171,7 @@ namespace RT64 {
                     for (int32_t f = workload.fbPairCount - 1; f >= 0; f--) {
                         const FramebufferPair &fbPair = workload.fbPairs[f];
                         bool interpolationCandidate = fbPair.earlyPresentCandidate();
-                        if (fbPair.drawColorRect.isEmpty()) {
+                        if (fbPair.displayColorRect(workloadConfig.aspectRatioScale > 1.0f).isEmpty()) {
                             continue;
                         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@
 #include "rsp_microcode.h"
 #include "audio.h"
 #include "input.h"
+#include "widescreen.h"
 #include "settings.h"
 #include "version.h"
 #include "paths.h"
@@ -187,6 +188,11 @@ static void update_gfx(void* /*gfx_data*/) {
     }
 
     SDL_Event event;
+    if (sdl_window) {
+        int width, height;
+        SDL_GetWindowSize(sdl_window, &width, &height);
+        snap::update_visibility_viewport(width, height);
+    }
     while (SDL_PollEvent(&event)) {
         switch (event.type) {
             case SDL_QUIT:

--- a/src/widescreen.cpp
+++ b/src/widescreen.cpp
@@ -1,0 +1,55 @@
+#include "widescreen.h"
+#include "settings.h"
+#include "recomp.h"
+#include <atomic>
+#include <bit>
+
+extern "C" void __real_Pokemon_GetFlag100(uint8_t*, recomp_context*);
+extern "C" void func_80364618_504A28(uint8_t*, recomp_context*);
+
+namespace snap {
+extern std::atomic<bool> g_app_level_resident;
+static std::atomic<float> expansion{1.0f};
+void update_visibility_viewport(int width, int height) {
+    expansion.store(visibility_expansion(width, height), std::memory_order_relaxed);
+}
+}
+
+extern "C" void Pokemon_GetFlag100(uint8_t* rdram, recomp_context* ctx) {
+    const gpr object = ctx->r4;
+    __real_Pokemon_GetFlag100(rdram, ctx);
+    const float expansion = snap::expansion.load(std::memory_order_relaxed);
+    if (expansion <= 1.0f || !snap::g_app_level_resident.load(std::memory_order_relaxed)) return;
+    {
+        std::lock_guard<std::mutex> lock(snap::settings_mutex());
+        if (!snap::settings().widescreen) return;
+    }
+
+    // Query draw eligibility independently of the photo collector's 12 slots.
+    // Do not change flag 0x100 or photo eligibility: those describe the native
+    // photo view. Scripted GObj hiding still runs before this draw callback.
+    const gpr pokemon = MEM_W(0x58, object);
+    if (MEM_HU(0x08, pokemon) & 0x40) { ctx->r2 = 0; return; }
+    if (std::bit_cast<float>(uint32_t(MEM_W(0x6C, pokemon))) > 10000.0f) {
+        ctx->r2 = 1;
+        return;
+    }
+
+    auto call = *ctx;
+    call.f_odd = call.mips3_float_mode ? &call.f1.u32l : &call.f0.u32h;
+    call.r4 = object;
+    call.r5 = MEM_W(0x100, pokemon);
+    call.r6 = MEM_W(0x104, pokemon);
+    call.r7 = MEM_W(0x108, pokemon);
+    // The retail callee stores arguments in the caller's home slots. Keep the
+    // original query's context and stack effects, apart from its return value.
+    const int32_t homes[4] = {MEM_W(0, call.r29), MEM_W(4, call.r29),
+                             MEM_W(8, call.r29), MEM_W(12, call.r29)};
+    func_80364618_504A28(rdram, &call);
+    // Its 0x40-byte frame leaves guMtxXFMF's x/y/z outputs at sp-4/-8/-12.
+    const float x = std::bit_cast<float>(uint32_t(MEM_W(-4, call.r29)));
+    const float y = std::bit_cast<float>(uint32_t(MEM_W(-8, call.r29)));
+    const float z = std::bit_cast<float>(uint32_t(MEM_W(-12, call.r29)));
+    for (int i = 0; i < 4; ++i) MEM_W(i * 4, call.r29) = homes[i];
+    ctx->r2 = call.r2 != 0 && snap::outside_wide_view(x, y, z, expansion);
+}

--- a/src/widescreen.h
+++ b/src/widescreen.h
@@ -1,0 +1,23 @@
+#ifndef SNAP_WIDESCREEN_H
+#define SNAP_WIDESCREEN_H
+#include <algorithm>
+#include <cmath>
+
+namespace snap {
+void update_visibility_viewport(int width, int height);
+
+inline float visibility_expansion(int width, int height) {
+    return height > 0 ? std::max(1.0f, float(width) / float(height) * 0.75f) : 1.0f;
+}
+
+// Retail camera-space rejection, with its truncation and vertical/depth limits.
+// The extra horizontal margin follows the renderer's expanded aspect ratio.
+inline bool outside_wide_view(float x, float y, float z, float expansion) {
+    if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(z) ||
+        z > -1.0f || z < -10000.0f) return true;
+    const float px = std::trunc(x * 228.506134f / z);
+    const float py = std::trunc(y * 228.506134f / z);
+    return std::fabs(px) > 240.0f * expansion || std::fabs(py) > 180.0f;
+}
+}
+#endif

--- a/tests/visibility_test.cpp
+++ b/tests/visibility_test.cpp
@@ -1,0 +1,120 @@
+#include "hle/rt64_framebuffer_pair.h"
+#include <cstdio>
+#include <cstdlib>
+#include <atomic>
+#include <bit>
+#include <vector>
+#include "settings.h"
+#include "widescreen.h"
+#include "recomp.h"
+
+namespace snap {
+std::atomic<bool> g_app_level_resident{true};
+static Settings test_settings;
+static std::mutex test_mutex;
+Settings& settings() { return test_settings; }
+std::mutex& settings_mutex() { return test_mutex; }
+}
+
+static float camera_x = 1200.0f, camera_y = 0.0f, camera_z = -1000.0f;
+extern "C" void __real_Pokemon_GetFlag100(uint8_t* rdram, recomp_context* ctx) {
+    ctx->r2 = (MEM_HU(8, MEM_W(0x58, ctx->r4)) & 0x100) != 0;
+    ctx->r16 = 0x12345678;
+}
+extern "C" void func_80364618_504A28(uint8_t* rdram, recomp_context* ctx) {
+    MEM_W(-4, ctx->r29) = std::bit_cast<uint32_t>(camera_x);
+    MEM_W(-8, ctx->r29) = std::bit_cast<uint32_t>(camera_y);
+    MEM_W(-12, ctx->r29) = std::bit_cast<uint32_t>(camera_z);
+    MEM_W(0, ctx->r29) = 0xDEADBEEF;
+    MEM_W(12, ctx->r29) = 0xBADCAFE;
+    ctx->f_odd[0] = 0x12345678;
+    ctx->r16 = 0;
+    ctx->r2 = 1;
+}
+extern "C" void Pokemon_GetFlag100(uint8_t*, recomp_context*);
+
+static int checks = 0;
+static void check(bool value, const char* message) {
+    if (!value) { std::fprintf(stderr, "FAIL: %s\n", message); std::exit(1); }
+    ++checks;
+}
+static RT64::FixedRect rect(int x0, int y0, int x1, int y1) {
+    RT64::FixedRect r; r.ulx = x0; r.uly = y0; r.lrx = x1; r.lry = y1; return r;
+}
+static bool equal(const RT64::FixedRect& a, const RT64::FixedRect& b) {
+    return a.ulx == b.ulx && a.uly == b.uly && a.lrx == b.lrx && a.lry == b.lry;
+}
+static void draw(RT64::FramebufferPair& pair, RT64::Projection::Type type, RT64::FixedRect scissor) {
+    pair.changeProjection(pair.projectionCount + 1, type);
+    RT64::GameCall call{};
+    call.callDesc.scissorRect = scissor;
+    call.callDesc.triangleCount = 1;
+    pair.addGameCall(call);
+}
+int main() {
+    using Type = RT64::Projection::Type;
+    RT64::FramebufferPair pair;
+    pair.reset();
+    const auto full = rect(0, 0, 1280, 960);
+    const auto inset = rect(120, 80, 1160, 880);
+    check(pair.displayColorRect(true).isEmpty(), "empty pass stays empty");
+    draw(pair, Type::Perspective, full);
+    check(pair.drawColorRect.isEmpty(), "reproduce a submitted 3D pass with no native pixels");
+    check(pair.displayColorRect(false).isEmpty(), "4:3 keeps original pass rejection");
+    check(equal(pair.displayColorRect(true), full), "wide display keeps complete offscreen Pokemon pass");
+    check(pair.drawColorRect.isEmpty() && pair.drawDepthRect.isEmpty(), "display coverage does not change native writeback bounds");
+    pair.drawColorRect = rect(200, 100, 500, 700);
+    check(equal(pair.displayColorRect(true), pair.drawColorRect), "existing native coverage unchanged");
+    pair.reset(); draw(pair, Type::Perspective, inset);
+    check(equal(pair.displayColorRect(true), inset), "viewfinder keeps its own scissor");
+    for (Type type : {Type::Rectangle, Type::Orthographic, Type::Triangle}) {
+        pair.reset(); draw(pair, type, full);
+        check(pair.displayColorRect(true).isEmpty(), "2D/offscreen copies do not acquire 3D display coverage");
+    }
+    pair.reset(); pair.changeProjection(1, Type::Perspective);
+    pair.projections[0].scissorRect = full;
+    check(pair.displayColorRect(true).isEmpty(), "unused perspective projection remains empty");
+    pair.reset(); draw(pair, Type::Perspective, rect(0, 0, 0, 0));
+    check(pair.displayColorRect(true).isEmpty(), "zero-area scissor still hides pass");
+    pair.reset(); draw(pair, Type::Perspective, inset); draw(pair, Type::Perspective, full);
+    check(equal(pair.displayColorRect(true), full), "multiple perspective passes retain all display coverage");
+    std::vector<uint8_t> memory(1024 * 1024);
+    uint8_t* rdram = memory.data();
+    recomp_context ctx{};
+    ctx.r4 = (gpr)(int32_t)0x80010000;
+    ctx.r29 = (gpr)(int32_t)0x80030000;
+    const gpr pokemon = (gpr)(int32_t)0x80011000;
+    MEM_W(0x58, ctx.r4) = pokemon;
+    MEM_H(8, pokemon) = 0x100;
+    MEM_W(0x6C, pokemon) = std::bit_cast<uint32_t>(1000.0f);
+    MEM_W(0, ctx.r29) = 42; MEM_W(12, ctx.r29) = 99;
+    snap::settings().widescreen = true;
+    for (const auto dimensions : {std::pair{640, 480}, {1600, 900}, {2520, 1080}, {3840, 1080}}) {
+        snap::update_visibility_viewport(dimensions.first, dimensions.second);
+        Pokemon_GetFlag100(rdram, &ctx);
+        check(ctx.r2 == (dimensions.first == 640), "4:3 rejection preserved; widened draw retained at 16:9, 21:9 and 32:9");
+        check(MEM_HU(8, pokemon) == 0x100, "native photo visibility flag remains unchanged");
+    }
+    check(ctx.r16 == 0x12345678 && ctx.f0.u32h == 0, "guest query registers preserved");
+    check(MEM_W(0, ctx.r29) == 42 && MEM_W(12, ctx.r29) == 99, "guest argument home slots preserved");
+    camera_x = 2500; Pokemon_GetFlag100(rdram, &ctx);
+    check(ctx.r2 == 0, "32:9 draws beyond narrower ultrawide gate");
+    snap::update_visibility_viewport(2520, 1080); Pokemon_GetFlag100(rdram, &ctx);
+    check(ctx.r2 == 1, "outside expanded horizontal view still rejected");
+    camera_x = 1200; camera_y = 1000; Pokemon_GetFlag100(rdram, &ctx);
+    check(ctx.r2 == 1, "vertical rejection preserved");
+    camera_y = 0; camera_z = 1; Pokemon_GetFlag100(rdram, &ctx);
+    check(ctx.r2 == 1, "behind-camera rejection preserved");
+    camera_z = -10001; Pokemon_GetFlag100(rdram, &ctx);
+    check(ctx.r2 == 1, "far camera-plane rejection preserved");
+    camera_z = -1000; MEM_W(0x6C, pokemon) = std::bit_cast<uint32_t>(10001.0f);
+    Pokemon_GetFlag100(rdram, &ctx); check(ctx.r2 == 1, "player-distance rejection preserved");
+    MEM_H(8, pokemon) = 0x140; Pokemon_GetFlag100(rdram, &ctx);
+    check(ctx.r2 == 0 && MEM_HU(8, pokemon) == 0x140, "retail flag-40 bypass without mutation");
+    MEM_H(8, pokemon) = 0x100; MEM_W(0x6C, pokemon) = 0;
+    snap::settings().widescreen = false; Pokemon_GetFlag100(rdram, &ctx);
+    check(ctx.r2 == 1, "widescreen disabled restores original query");
+    snap::settings().widescreen = true; snap::g_app_level_resident = false;
+    Pokemon_GetFlag100(rdram, &ctx); check(ctx.r2 == 1, "non-course queries unchanged");
+    std::printf("PASS: %d production display-bound and draw-eligibility checks\n", checks);
+}

--- a/tools/hook_funcs.py
+++ b/tools/hook_funcs.py
@@ -12,6 +12,8 @@ import re
 import sys
 
 HOOKED = [
+    # Widescreen draw eligibility, independent of the native photo collector.
+    'Pokemon_GetFlag100',
     # Overlay residency tracking and the RSP memory probes.
     'dmaLoadOverlay',
     # The VPK0 segment loads. The main menu's segment carries the sprite font


### PR DESCRIPTION
With Widescreen enabled, Pokemon entirely outside the original 4:3 frame could disappear even while they should be visible in the expanded side margins. This change keeps those Pokemon render passes and expands their horizontal draw eligibility to follow the current window aspect ratio.

**AI disclosure:** This PR was generated using AI assistance (OpenAI Codex), including implementation, tests, documentation, and the PR description. The requester playtested the updated widescreen build and reported that it looks good.

The renderer previously discarded framebuffer passes with empty native color dirty rectangles before applying widescreen projection. Pokemon Snap's photo detector splits Pokemon into separate passes, making this visible as a sharp cutoff at the original frame edges. A display-only perspective-scissor fallback keeps those passes without enlarging native RAM writeback bounds. The game-side `Pokemon_GetFlag100` hook also refreshes draw eligibility for wide views independently of the photo collector's 12 slots, without modifying photo eligibility flags.

Uses the existing Widescreen setting (still opt-in); no new bindings or preferences. The separate mouse-controls PR #4 is not required or included.

**Outstanding: draw distance remains unresolved and may be addressed in a later commit.** This fixes the horizontal frame-edge cutoff. Existing distance limits, scripted hiding, and course spawn timing remain in effect.

Validation:

- Windows Release executable builds on this standalone branch; the production `SnapVisibilityTest` harness passes 32 checks.
- The same culling implementation was visually tested on Beach at 4:3, 16:9, 21:9, and 32:9, including viewfinder use, turns in both directions, and camera interpolation. Baseline/fixed captures show the missing Pidgey at the old left frame boundary becoming visible.
- A captured live run resized through 16:9, 32:9, 4:3, and 21:9. These runs reported no crash or graphics-buffer overflow.
- A 400-second photo regression run passed 30 per-Pokemon scoring-buffer checks and exported 40 photos without a crash. This checks buffer consistency, not identical final scores between aspect ratios. The native scoring path is retained.
- Other courses and non-Windows builds have not been visually validated for this change.

`docs/WIDESCREEN-CULLING.md` explains the cause, implementation, outstanding draw-distance work, and harness instructions. Saves, ROMs, local settings, and generated game code are not included.
